### PR TITLE
Fix string separation path of member

### DIFF
--- a/src/Mapster.Tests/WhenMappingMemberNameContainingPeriod.cs
+++ b/src/Mapster.Tests/WhenMappingMemberNameContainingPeriod.cs
@@ -126,6 +126,34 @@ public class WhenMappingMemberNameContainingPeriod
     }
 
     [TestMethod]
+    public void Using_Property_Path_String_Nested_Is_Supported()
+    {
+        // Create a target type with a property that contains periods
+        Type targetType = new TestTypeBuilder()
+            .AddProperty<Nested>(MemberName)
+            .CreateType();
+
+
+        // Create the config, both ways
+        TypeAdapterConfig
+            .GlobalSettings
+            .NewConfig(typeof(Source), targetType)
+            .Map(MemberName + "/NestedValue", nameof(Source.Value));
+        TypeAdapterConfig
+            .GlobalSettings
+            .NewConfig(targetType, typeof(Source))
+            .Map(nameof(Source.Value), MemberName + "/NestedValue");
+
+        // Execute the mapping both ways
+        Source source = new() { Value = 551 };
+        object target = source.Adapt(typeof(Source), targetType);
+        Source adaptedSource = target.Adapt<Source>();
+
+        Assert.AreEqual(source.Value, adaptedSource.Value);
+    }
+
+    [Ignore]
+    [TestMethod]
     public void Object_To_Dictionary_Map()
     {
         var poco = new SimplePoco
@@ -174,6 +202,11 @@ public class WhenMappingMemberNameContainingPeriod
     private class Source
     {
         public int Value { get; set; }
+    }
+
+    private class Nested
+    {
+        public int NestedValue { get; set; }
     }
 
     private class TestTypeBuilder

--- a/src/Mapster/TypeAdapterConfig.cs
+++ b/src/Mapster/TypeAdapterConfig.cs
@@ -175,7 +175,13 @@ namespace Mapster
         {
             var key = new TypeTuple(typeof(TSource), typeof(TDestination));
             var settings = GetSettings(key);
-            return new TypeAdapterSetter<TSource, TDestination>(settings, this);
+
+            var result = new TypeAdapterSetter<TSource, TDestination>(settings, this);
+
+            result.TSource = typeof(TSource);
+            result.TDestination = typeof(TDestination);
+
+            return result; 
         }
 
 
@@ -189,7 +195,13 @@ namespace Mapster
         {
             var key = new TypeTuple(sourceType, destinationType);
             var settings = GetSettings(key);
-            return new TypeAdapterSetter(settings, this);
+
+            var result = new TypeAdapterSetter(settings, this);
+
+            result.TSource = sourceType;
+            result.TDestination = destinationType;
+
+            return result;
         }
 
 

--- a/src/Mapster/TypeAdapterSetter.cs
+++ b/src/Mapster/TypeAdapterSetter.cs
@@ -15,6 +15,9 @@ namespace Mapster
         protected const string ResultParameterName = "result";
         protected const string DestinationParameterName = "destination";
 
+        public Type TSource { get; set; }
+        public Type TDestination { get; set; }
+
         public readonly TypeAdapterSettings Settings;
         public readonly TypeAdapterConfig Config;
         public TypeAdapterSetter(TypeAdapterSettings settings, TypeAdapterConfig config)
@@ -175,18 +178,30 @@ namespace Mapster
         }
 
         public static TSetter Map<TSetter>(
-            this TSetter setter, string destinationMemberName, string sourceMemberName) where TSetter : TypeAdapterSetter
+            this TSetter setter, string destinationMemberName, string sourceMemberName, char? altSeparator = null) where TSetter : TypeAdapterSetter
         {
             setter.CheckCompiled();
 
-            setter.Settings.Resolvers.Add(new InvokerModel
-            {
-                DestinationMemberPath = destinationMemberName.Split('.'),
-                SourceMemberPath = sourceMemberName.Split('.'),
-                Condition = null
-            });
 
-            return setter;
+
+           var MappingTypes =  new TypeTuple(setter.TSource,setter.TDestination);
+
+            if (MappingTypes.IsValidMemeberName(destinationMemberName,sourceMemberName, altSeparator))
+            {
+                setter.Settings.Resolvers.Add(new InvokerModel
+                {
+                    DestinationMemberPath = MappingTypes.Destination.GetSeparatedMemeberPath(destinationMemberName,altSeparator),
+                    SourceMemberPath = MappingTypes.Source.GetSeparatedMemeberPath(sourceMemberName, altSeparator),
+                    Condition = null
+                });
+                return setter;
+            }
+           
+               
+            throw new Exception($"{MappingTypes.GetNameOfTypeWithUnsupportedMemeberName()} " +
+                $"Contains Members with unsupported Names. Use the Alternate Separator (' / ') " +
+                $"to access properties of internal members -> .Map(MemberName + \"/Id\", c => c.Id)");
+
         }
 
         public static TSetter EnableNonPublicMembers<TSetter>(this TSetter setter, bool value) where TSetter : TypeAdapterSetter

--- a/src/Mapster/Utils/ReflectionUtils.cs
+++ b/src/Mapster/Utils/ReflectionUtils.cs
@@ -380,5 +380,60 @@ namespace Mapster
             var isExternalInitType = typeof(System.Runtime.CompilerServices.IsExternalInit);
             return setMethod.ReturnParameter.GetRequiredCustomModifiers().Contains(isExternalInitType);
         }
+
+        public static bool IsTypeWithUnsupportedMemeberName(this Type type)
+        {
+            return
+                type.GetFieldsAndProperties().Any(x => x.Name.Contains('.'));
+               
+        }
+
+        private static bool IsUnsupportedMemeberName(this TypeTuple tuple)
+        {
+            return
+                tuple.Source.IsTypeWithUnsupportedMemeberName()
+                || tuple.Destination.IsTypeWithUnsupportedMemeberName();
+        }
+
+        public static bool IsValidMemeberName(this TypeTuple tuple, string destinationMemberName, string sourceMemberName, char? AltSeparator)
+        {
+
+            var sourseMembers = tuple.Source.GetFieldsAndProperties();
+            var destinationMemebers = tuple.Destination.GetFieldsAndProperties();
+
+            var altSeparator = AltSeparator.HasValue ? AltSeparator.Value : '/';
+
+            if (tuple.IsUnsupportedMemeberName())
+            {
+                var isTopLevelMember = sourseMembers.Any(x => x.Name == sourceMemberName)
+                && destinationMemebers.Any(x => x.Name == destinationMemberName);
+
+                if (isTopLevelMember)
+                    return true;
+                else
+                    return sourceMemberName.Contains(altSeparator)
+                    || destinationMemberName.Contains(altSeparator);
+            }
+
+            return true;
+        }
+
+        public static string[] GetSeparatedMemeberPath(this Type type, string MemberPath, char? altSeparator)
+        {
+            var altseparator = altSeparator.HasValue ? altSeparator.Value : '/';
+
+            if (type.IsTypeWithUnsupportedMemeberName() || MemberPath.Contains(altseparator))
+                return MemberPath.Split(altseparator);
+            else
+                return MemberPath.Split('.');
+        }
+
+        public static string GetNameOfTypeWithUnsupportedMemeberName(this TypeTuple tuple)
+        {
+            if (tuple.Source.IsTypeWithUnsupportedMemeberName())
+                return tuple.Source.Name;
+            else
+                return tuple.Destination.Name;
+        }
     }
 }


### PR DESCRIPTION
This should work within your original concept.

But requires specifying an alternative separator for the inner members.
Since it is difficult to determine from the string what the Property Name is when using dots.